### PR TITLE
hotfix resume url

### DIFF
--- a/about.html
+++ b/about.html
@@ -64,7 +64,7 @@
               <p>September 2012 — May 2016</p>
               <h3>Graphic Designer &#64; Associated Students Inc.</h3>
               <p>September 2011 — June 2012</p>
-              <a class="bdr-btm-1" href="img/jocelynw_resume.pdf">Download Full Résumé</a>
+              <a class="bdr-btm-1" href="https://bit.ly/2Cvh3TN">Download Full Résumé</a>>
             </div>
           </div>
         </section>


### PR DESCRIPTION
Issue: `jQuery is unable to read the .pdf format as it is a reserved character`
- [x] adjust url with bitly as a workaround  