### PR TITLE
hotfix: remove extraneous closing bracket

### DIFF
--- a/about.html
+++ b/about.html
@@ -64,7 +64,7 @@
               <p>September 2012 — May 2016</p>
               <h3>Graphic Designer &#64; Associated Students Inc.</h3>
               <p>September 2011 — June 2012</p>
-              <a class="bdr-btm-1" href="https://bit.ly/2Cvh3TN">Download Full Résumé</a>>
+              <a class="bdr-btm-1" href="https://bit.ly/2Cvh3TN">Download Full Résumé</a>
             </div>
           </div>
         </section>


### PR DESCRIPTION
Extraneous closing bracket in the `about.html` page that is appended to the `Download Full Résumé` link.

- [x] remove closing bracket